### PR TITLE
Add version number to migrations directory.

### DIFF
--- a/migrations.html.md.erb
+++ b/migrations.html.md.erb
@@ -15,7 +15,7 @@ To update a product tile, tile authors must complete the following steps:
 
 1. Name the file in the format `TIMESTAMP_NAME.js`. TIMESTAMP must be in the form “YYYYMMDDHHMM” to indicate when the author created the migration. NAME is a human-readable name for the migration, for example, `201606150900_example-product.js`. 
 
-1. Copy the `TIMESTAMP_NAME.js` file to the PRODUCT/migrations directory.
+1. Copy the `TIMESTAMP_NAME.js` file to the PRODUCT/migrations/v1 directory.
 
 
 ### <a id='import'></a>Example JavaScript Migration File###


### PR DESCRIPTION
The JavaScript migrations file needs to be under PRODUCT/migrations/JAVASCRIPT_MIGRATIONS_VERSION. We were bitten by this where we only placed it under PRODUCT/migrations and received an error. Right now only v1 is supported so we placed that there rather than explain further.

-- @pivotal-todd-ritchie  & @badie